### PR TITLE
std-feature on GenesisConfig

### DIFF
--- a/src/mockups/avg_currency.rs
+++ b/src/mockups/avg_currency.rs
@@ -43,7 +43,7 @@ pub mod pallet {
         pub avg_init: BalanceOf<T>,
     }
 
-    // #[cfg(feature = "std")]
+    #[cfg(feature = "std")]
     impl<T: Config> Default for GenesisConfig<T> {
         fn default() -> GenesisConfig<T> {
             GenesisConfig {


### PR DESCRIPTION
Added std-feature to `GenesisConfig`, then peaq-network-node compiles...